### PR TITLE
Search PATH for usable NASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "nasm-rs"
 readme = "README.markdown"
 repository = "https://github.com/medek/nasm-rs"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies.rayon]
 optional = true


### PR DESCRIPTION
This is because Apple's developer tools ship with an unusable 10-year-old fork of NASM, but the PATH may also contain a contemporary NASM from Homebrew.

This fixes #7