### PR TITLE
compile_objects()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,14 @@ impl Build {
         self
     }
 
+    /// Set multiple files
+    pub fn files<P: AsRef<Path>, I: IntoIterator<Item=P>>(&mut self, files: I) -> &mut Self {
+        for file in files {
+            self.file(file);
+        }
+        self
+    }
+
     /// Add a directory to the `-I` include path
     pub fn include<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
         let mut flag = format!("-I{}", dir.as_ref().display());


### PR DESCRIPTION
Alternative to #12

I've found that instead of creating a static library on Windows, I can make `.o` files and finish compilation using the `cc` crate.
  
\+ couple more functions for the builder API