### PR TITLE
Next release?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "nasm-rs"
 readme = "README.markdown"
 repository = "https://github.com/medek/nasm-rs"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies.rayon]
 optional = true


### PR DESCRIPTION
Please make a new release on crates.io. cc-rs has updated Rayon, and without the upgrade in c301a5fc36c4e4d511ffb90fa9de367d1dd41147 this makes Cargo needlessly compile two versions of Rayon.

Alternatively, if you gave me access to the GitHub repository and [crates.io](https://crates.io/users/kornelski) account, I could release it without bugging you :)