### PR TITLE
Bump rayon version to match cc-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ license = "MIT OR Apache-2.0"
 name = "nasm-rs"
 readme = "README.markdown"
 repository = "https://github.com/medek/nasm-rs"
-version = "0.1.2"
+version = "0.1.3"
 
 [dependencies.rayon]
 optional = true
-version = "0.9"
+version = "1.0"
 
 [features]
 parallel = ["rayon"]


### PR DESCRIPTION
cc-rs now uses rayon 1.0, so current nasm-rs causes duplicate rayon 0.9 to be compiled as well.