### PR TITLE
Unbreak consumers on more Unices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,19 +10,17 @@ use std::path::{Path, PathBuf};
 
 fn x86_triple(os: &str) -> &'static str {
     match os {
-        "linux" => "-felf32",
         "darwin" => "-fmacho32",
         "windows" => "-fwin32",
-        _ => ""
+        _ => "-felf32"
     }
 }
 
 fn x86_64_triple(os: &str) -> &'static str {
     match os {
-        "linux" => "-felf64",
         "darwin" => "-fmacho64",
         "windows" => "-fwin64",
-        _ => ""
+        _ => "-felf64"
     }
 }
 


### PR DESCRIPTION
NASM [defaults](https://repo.or.cz/nasm.git/blob/nasm-2.14:/output/outform.h#l262) to `bin` format (e.g. DOS .COM, .SYS). DragonFly, FreeBSD, NetBSD, OpenBSD, Solaris, GNU Hurd and probably more systems use [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format). NASM supports more formats but those are less likely to be supported by Rust and aren't shared on many platforms.

Found via rav1e on FreeBSD x86_64:
```
$ cargo build
[...]
     Running `/path/to/rav1e/target/debug/build/rav1e-930659fb03421608/build-script-build`
error: failed to run custom build command for `rav1e v0.1.0 (/a/rav1e)`
process didn't exit successfully: `/path/to/rav1e/target/debug/build/rav1e-930659fb03421608/build-script-build` (exit code: 101)
--- stdout
running: "nasm" "" "-g" "-I/path/to/rav1e/target/debug/build/rav1e-bf67f461e7fd7434/out/" "-Isrc/" "/path/to/rav1e/src/x86/ipred.asm" "-o" "/path/to/rav1e/target/debug/build/rav1e-bf67f461e7fd7434/out/src/x86/ipred.o"

--- stderr
/path/to/rav1e/src/x86/ipred.asm:100: error: impossible combination of address sizes
src/ext/x86/x86inc.asm:1424: ... from macro `movdqu' defined here
src/ext/x86/x86inc.asm:1288: ... from macro `RUN_AVX_INSTR' defined here
src/ext/x86/x86inc.asm:1748: ... from macro `vmovdqu' defined here
[...]
thread 'main' panicked at 'nonzero exit status: exit code: 1', /home/foo/.cargo/git/checkouts/nasm-rs-4e8d02e8a0db2eea/7c01c74/src/lib.rs:340:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```
