### PR TITLE
Remove trailing spaces from the version string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ impl Build {
     fn is_nasm_new_enough(&self, nasm_path: &Path) -> Result<(), String> {
         let version = get_output(Command::new(nasm_path).arg("-v"))?;
         let (major, minor, micro) = self.min_version;
-        let ver: Vec<usize> = version
+        let ver: Vec<usize> = version.trim_end()
             .split(" ")
             .skip(2)
             .next()


### PR DESCRIPTION
Address:
```
Some((2, 14, 0)) "NASM version 2.14.02\n" (2, 14, 2)
thread 'main' panicked at 'Invalid version component: ParseIntError { kind: InvalidDigit }', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/nasm-rs-0.1.8/src/lib.rs:325:30
```