### PR TITLE
Fix nasm version detection and avoid panicking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ license = "MIT OR Apache-2.0"
 name = "nasm-rs"
 readme = "README.markdown"
 repository = "https://github.com/medek/nasm-rs"
-version = "0.1.8"
+version = "0.2.0"
+
+[dependencies]
+arrayvec = "0.5"
 
 [dependencies.rayon]
 optional = true


### PR DESCRIPTION
nasm version parsing was failing on version strings
with only 2 parts, which is common for nasm releases.

Fixes xiph/rav1e#2482

Also avoids panics/unwraps/expects where reasonable
in favor of bubbling them up as `Err`s.
Libraries should avoid panicking when possible,
and allow the caller to handle the errors.
This requires a breaking change in function signatures
to return `Result`s.