### PR TITLE
Drop arrayvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,11 @@ name = "nasm-rs"
 readme = "README.markdown"
 repository = "https://github.com/medek/nasm-rs"
 version = "0.2.0"
-
-[dependencies]
-arrayvec = "0.5"
+edition = "2018"
 
 [dependencies.rayon]
 optional = true
-version = "1.0"
+version = "1.4"
 
 [features]
 parallel = ["rayon"]

--- a/README.markdown
+++ b/README.markdown
@@ -1,14 +1,14 @@
 # NASM
 
-Run NASM during your Cargo build.
+Run [NASM](https://www.nasm.us/) during your Cargo build.
 
 ```rust
-extern crate nasm_rs;
-
 fn main() {
     nasm_rs::compile_library("libfoo.a", &["foo.s", "bar.s"]);
 }
 ```
+
+It requires a `nasm` executable already installed on the system.
 
 ## License
 


### PR DESCRIPTION
Arrayvec is an overkill.

I've bumped rayon, so that `-Z minimal-versions` doesn't break.

I've upgraded edition flag, because nasm-rs already requires Rust 1.36+.

