### PR TITLE
Fixed bug placing output files in source directory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ impl Build {
         src: &Path,
         dst: &Path,
     ) -> Result<PathBuf, String> {
-        let obj = dst.join(file).with_extension("o");
+        let obj = dst.join(file.file_name().unwrap()).with_extension("o");
         let mut cmd = Command::new(nasm);
         cmd.args(&new_args[..]);
         std::fs::create_dir_all(&obj.parent().unwrap()).unwrap();


### PR DESCRIPTION
The way `Path::join()` works, it will entirely replace the original path if it is given an absolute path to join to it. This is causing the output from nasm to go into the source folder, not `out_dir` as intended. Joining just the file name of the source file instead of the whole path should fix this bug.