### PR TITLE
Implement jobserver-based build parallelization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ repository = "https://github.com/medek/nasm-rs"
 version = "0.2.5"
 edition = "2018"
 
-[dependencies.rayon]
+[dependencies.jobserver]
 optional = true
-version = "1.4"
+version = "0.1"
 
 [features]
-parallel = ["rayon"]
+parallel = ["jobserver"]


### PR DESCRIPTION
Closes #40.

I'm opening as a draft because I want to test this more. I'm otherwise happy/done with the implementation. Feel free to leave feedback.

Some info:
- When building through `cargo` or `make`, `Client::from_env()` is generally expected to be successful. So the `or_else` handling is kept simple because it should be rare
- A non-zero exit code in a NASM invocation does not cause a thread panic. A thread panic only happens when the code in a thread (`self.compile_file`) panics
- Calling `resume_unwind` on thread panics should give us useful backtraces (still need to test this)