### PR TITLE
Avoid writing debugging information to stdout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ repository = "https://github.com/medek/nasm-rs"
 version = "0.3.0"
 edition = "2018"
 
+[dependencies.log]
+version = "0.4"
+
 [dependencies.jobserver]
 optional = true
 version = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ use std::process::Stdio;
 #[cfg(feature = "parallel")]
 use std::sync::OnceLock;
 
+use log::info;
+
 #[cfg(feature = "parallel")]
 static JOBSERVER: OnceLock<jobserver::Client> = OnceLock::new();
 
@@ -488,7 +490,7 @@ fn get_output(cmd: &mut Command) -> Result<String, String> {
 }
 
 fn run(cmd: &mut Command) -> Result<(), String> {
-    println!("running: {:?}", cmd);
+    info!("running: {:?}", cmd);
 
     let status = match cmd
         .stdout(Stdio::inherit())


### PR DESCRIPTION
nasm-rs currently prints the command it is about to run to stdout each time it gets invoked. It would be nice not to have this debugging output (or to able to suppress it).