### PR TITLE
Allow configuring path to NASM via env var

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ impl Build {
             archiver: None,
             archiver_is_msvc: None,
             out_dir: None,
-            nasm: None,
+            nasm: env::var("NASM").ok(),
             target: None,
             min_version: (1, 0, 0),
             debug: env::var("DEBUG").ok().map_or(false, |d| d != "false"),


### PR DESCRIPTION
This makes nasm easier to use with hermetic build systems such as Bazel.

If/when this lands, would it be possible to cut a release?

Fixes https://github.com/medek/nasm-rs/issues/43